### PR TITLE
Fix bug where `nodeattr` still points to the /opt/clusterware

### DIFF
--- a/tools/genders/package/build.sh
+++ b/tools/genders/package/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cw_ROOT=${cw_ROOT:-/opt/clusterware}
+FL_ROOT=${FL_ROOT:-/opt/flight}
 package_name='genders'
 
 if [ -f ./${package_name}.zip ]; then
@@ -19,10 +19,10 @@ cp -pr ../etc "${temp_dir}/data"
 
 curl -L "https://github.com/chaos/genders/releases/download/genders-1-22-1/genders-1.22.tar.gz" -o /tmp/genders-source.tar.gz
 tar -C /tmp -xzf "/tmp/genders-source.tar.gz"
-mkdir -p "${cw_ROOT}"/opt/genders
+mkdir -p "${FL_ROOT}"/opt/genders
 pushd /tmp/genders-*
-./configure --prefix="${cw_ROOT}/opt/genders" \
-  --with-genders-file="/opt/clusterware/etc/genders" \
+./configure --prefix="${FL_ROOT}/opt/genders" \
+  --with-genders-file="${FL_ROOT}/etc/genders" \
   --without-java-extensions \
   --without-perl-extensions \
   --without-python-extensions
@@ -37,7 +37,7 @@ popd
 
 pushd "${temp_dir}" > /dev/null
 mkdir -p "${temp_dir}/data/opt"
-cp -R "${cw_ROOT}/opt/genders" "${temp_dir}/data/opt"
+cp -R "${FL_ROOT}/opt/genders" "${temp_dir}/data/opt"
 zip -r ${package_name}.zip *
 popd > /dev/null
 

--- a/tools/genders/package/metadata.json
+++ b/tools/genders/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "genders",
-    "version": "1.22.0+clusterware0",
+    "version": "1.22.0+flight0",
     "summary": "A static cluster configuration database used for cluster configuration management",
     "dependencies": [
     ]

--- a/tools/pdsh/package/build.sh
+++ b/tools/pdsh/package/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-cw_ROOT=${cw_ROOT:-/opt/clusterware}
-if [ ! -d "${cw_ROOT}"/opt/genders ]; then
+FL_ROOT=${FL_ROOT:-/opt/flight}
+if [ ! -d "${FL_ROOT}"/opt/genders ]; then
     echo "Genders must be installed to compile this package."
     exit 1
 fi
@@ -24,14 +24,14 @@ cp ../pdsh-module.template ../motd.sh "${temp_dir}/data"
 
 curl -L "https://github.com/chaos/pdsh/releases/download/pdsh-2.33/pdsh-2.33.tar.gz" -o /tmp/pdsh-source.tar.gz
 tar -C /tmp -xf "/tmp/pdsh-source.tar.gz"
-mkdir -p "${cw_ROOT}"/opt/pdsh
+mkdir -p "${FL_ROOT}"/opt/pdsh
 pushd /tmp/pdsh-*
-./configure --prefix="${cw_ROOT}/opt/pdsh" --with-ssh \
+./configure --prefix="${FL_ROOT}/opt/pdsh" --with-ssh \
   --with-rcmd-rank-list=ssh,rsh,exec \
   --with-genders \
   --with-readline \
-  CPPFLAGS="-I${cw_ROOT}/opt/genders/include" \
-  LDFLAGS="-L${cw_ROOT}/opt/genders/lib"
+  CPPFLAGS="-I${FL_ROOT}/opt/genders/include" \
+  LDFLAGS="-L${FL_ROOT}/opt/genders/lib"
 make
 make install
 popd
@@ -39,7 +39,7 @@ popd
 
 pushd "${temp_dir}" > /dev/null
 mkdir -p "${temp_dir}/data/opt"
-cp -R "${cw_ROOT}/opt/pdsh" "${temp_dir}/data/opt"
+cp -R "${FL_ROOT}/opt/pdsh" "${temp_dir}/data/opt"
 zip -r ${package_name}.zip *
 popd > /dev/null
 

--- a/tools/pdsh/package/metadata.json
+++ b/tools/pdsh/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "pdsh",
-    "version": "2.33.0+clusterware0",
+    "version": "2.33.0+flight0",
     "summary": "A high performance, parallel remote shell utility",
     "dependencies": [
       "alces/genders",


### PR DESCRIPTION
The location of the default genders file is statically compiled into `nodeattr`. When the `root` changed from `/opt/clusterware` to `/opt/flight-direct`, it was not updated in the packages. The fix is to recompile `genders` with the updated path.

Both the `pdsh` and `genders` packages need to be recompiled as they both have independent version of `nodeattr`. Fixes #3 and part of the solution for #5 