### PR TITLE
Fix genders where the envvar patch wasn't being applied

### DIFF
--- a/tools/genders/package/build.sh
+++ b/tools/genders/package/build.sh
@@ -19,7 +19,14 @@ mkdir -p "${temp_dir}/data"
 
 cp -pr ../etc "${temp_dir}/data"
 
-curl -L "https://github.com/chaos/genders/releases/download/genders-1-22-1/genders-1.22.tar.gz" -o /tmp/genders-source.tar.gz
+# Set the version number so the build file names are known in advance
+major_version='1'
+minor_version='22'
+patch_version='1'
+tag="${major_version}-${minor_version}-${patch_version}"
+version="${major_version}.${minor_version}"
+
+curl -L "https://github.com/chaos/genders/releases/download/genders-$tag/genders-${version}.tar.gz" -o /tmp/genders-source.tar.gz
 tar -C /tmp -xzf "/tmp/genders-source.tar.gz"
 mkdir -p "${FL_ROOT}"/opt/genders
 pushd /tmp/genders-*

--- a/tools/genders/package/build.sh
+++ b/tools/genders/package/build.sh
@@ -37,7 +37,7 @@ pushd /tmp/genders-*
   --without-python-extensions
 popd
 
-patch -d /tmp/genders-* -p0 < ../genders-file-envvar.patch
+patch -d /tmp/genders-$version -p0 < ../genders-file-envvar.patch
 
 pushd /tmp/genders-*
 make

--- a/tools/genders/package/build.sh
+++ b/tools/genders/package/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 FL_ROOT=${FL_ROOT:-/opt/flight-direct}
 package_name='genders'
 

--- a/tools/genders/package/metadata.json
+++ b/tools/genders/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "genders",
-    "version": "1.22.0+flight0",
+    "version": "1.22.0+flight1",
     "summary": "A static cluster configuration database used for cluster configuration management",
     "dependencies": [
     ]

--- a/tools/pdsh/package/build.sh
+++ b/tools/pdsh/package/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 FL_ROOT=${FL_ROOT:-/opt/flight-direct}
 if [ ! -d "${FL_ROOT}"/opt/genders ]; then
     echo "Genders must be installed to compile this package."


### PR DESCRIPTION
When the `genders` package was being built, the `patch` was failing to be applied. This is because the wild card matching was picking up the path to the tar balls and not the configured directory. Naturally this caused the patch to fail.

It has been updated to apply the patch to an explicit path based off version numbers. Also the build will fail if anything exits non-zero.

Fixes #12 