### PR TITLE
Fix profile builds

### DIFF
--- a/profiles/flight-compute/package/build.sh
+++ b/profiles/flight-compute/package/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+package_name="flight-compute"
+
+if [ -f ./${package_name}.zip ]; then
+  echo "Replacing existing ${package_name}.zip in this directory"
+  rm ./${package_name}.zip
+fi
+
+temp_dir=$(mktemp -d /tmp/${package_name}-build-XXXXX)
+
+cp -r * "${temp_dir}"
+
+pushd "${temp_dir}" > /dev/null
+  zip -r ${package_name}.zip *
+popd > /dev/null
+
+mv "${temp_dir}"/${package_name}.zip .
+
+rm -rf "${temp_dir}"

--- a/profiles/flight-login/package/build.sh
+++ b/profiles/flight-login/package/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+package_name="flight-login"
+
+if [ -f ./${package_name}.zip ]; then
+  echo "Replacing existing ${package_name}.zip in this directory"
+  rm ./${package_name}.zip
+fi
+
+temp_dir=$(mktemp -d /tmp/${package_name}-build-XXXXX)
+
+cp -r * "${temp_dir}"
+
+pushd "${temp_dir}" > /dev/null
+  zip -r ${package_name}.zip *
+popd > /dev/null
+
+mv "${temp_dir}"/${package_name}.zip .
+
+rm -rf "${temp_dir}"

--- a/profiles/flight-login/package/metadata.json
+++ b/profiles/flight-login/package/metadata.json
@@ -7,7 +7,8 @@
     "dependencies": [
         "alces/flight-compute",
         "alces/clusterware-docs",
-        "alces/clusterware-ssh"
+        "alces/clusterware-ssh",
+        "alces/clusterware-sessions"
     ]
   }
 }


### PR DESCRIPTION
The build scripts weren't actually doing anything so the profiles wouldn't build. This change addresses that, the profiles have been built, pushed to the upstream package server and tested.