### PR TITLE
Explicitly require tempfile within the package

### DIFF
--- a/flight-direct/flight-syncer/lib/flight_syncer/sync_manifest.rb
+++ b/flight-direct/flight-syncer/lib/flight_syncer/sync_manifest.rb
@@ -2,6 +2,7 @@
 require 'yaml'
 require 'open-uri'
 require 'fileutils'
+require 'tempfile'
 
 module FlightSyncer
   class SyncManifest


### PR DESCRIPTION
This was implicitly being required somewhere else. However something has
changed and now it is not. IDK why, it just is. So we should probably
require it explicitly.

OHHH Ruby, you're a gem