### PR TITLE
Rebrand `alces` to `flight

### DIFF
--- a/clusterware/clusterware-about/libexec/about/actions/help
+++ b/clusterware/clusterware-about/libexec/about/actions/help
@@ -45,7 +45,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces about list
+    $cw_BINNAME about list
 
   DESCRIPTION:
 
@@ -58,8 +58,8 @@ help_for_show() {
     cat <<EOF
   SYNOPSIS:
 
-    alces about show <index|name>
-    alces about [<index|name>]
+    $cw_BINNAME about show <index|name>
+    $cw_BINNAME about [<index|name>]
 
   DESCRIPTION:
 
@@ -77,7 +77,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces about help [<command>]
+    $cw_BINNAME about help [<command>]
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-about/package/metadata.json
+++ b/clusterware/clusterware-about/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "clusterware-about",
-    "version": "2.0.0-dev",
+    "version": "2.0.1",
     "summary": "Access to cluster-specific documentation",
     "dependencies": [
       "alces/clusterware-docs"

--- a/clusterware/clusterware-about/var/lib/docs/base/about/00-intro.md
+++ b/clusterware/clusterware-about/var/lib/docs/base/about/00-intro.md
@@ -15,40 +15,40 @@ complexity of working with HPC environments:
 
   * Help and support:
 
-    The `alces about` tool (this one!) provides information about how
+    The `flight about` tool (this one!) provides information about how
     to get the most out of your Alces Flight environment.  For further
     support, visit the Alces Flight Community site at
     <https://community.alces-flight.com> where you can discuss your
     questions and HPC requirements with the community.
 
-    For "how-to" guides on multiple subjects, try the `alces howto`
+    For "how-to" guides on multiple subjects, try the `flight howto`
     tool.
 
   * Job script templates:
 
-    Create job scripts for your HPC tasks using the `alces template`
+    Create job scripts for your HPC tasks using the `flight template`
     tool, which provides access to multiple job script templates
     tailored for this particular HPC system.
 
   * Software and configuration:
 
-    Install and manage self-service software with the `alces gridware`
+    Install and manage self-service software with the `flight gridware`
     tool, which provides access to a curated set of HPC applications
     built and tested by the Alces Flight crew.
 
     Add additional capabilities to your Alces Clusterware environment,
     manage data sets, scripts and your custom software builds using
-    the `alces forge` tool.
+    the `flight forge` tool.
 
   * Data storage and management:
 
-    Use the `alces storage` tool to configure simple access to public
+    Use the `flight storage` tool to configure simple access to public
     and private object storage, such as Amazon S3 and Dropbox and to
     manage access to local data repositories.
 
   * Interactive GUI sessions:
 
-    When you need to deal with GUI applications, use the `alces
+    When you need to deal with GUI applications, use the `flight
     session` tool to create desktop sessions you can connect to using
     a VNC desktop client from your workstation, allowing you to run
     your graphical tools for workload setup, execution and data
@@ -59,7 +59,7 @@ complexity of working with HPC environments:
 Additional software, suited to the kind of HPC problems you want to
 solve, can be obtained via self-service using the Alces Gridware tool.
 Complete with a curated set of software packages provided by Alces
-Flight, the `alces gridware` tool gives you the capability to build
+Flight, the `flight gridware` tool gives you the capability to build
 from source code or install from a set of preprepared binary builds.
 
 ## LICENSE

--- a/clusterware/clusterware-compute/libexec/compute/actions/help
+++ b/clusterware/clusterware-compute/libexec/compute/actions/help
@@ -45,7 +45,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces compute help [<command>]
+    $cw_BINNAME compute help [<command>]
 
   DESCRIPTION:
 
@@ -59,7 +59,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces compute list
+    $cw_BINNAME compute list
 
   DESCRIPTION:
 
@@ -72,7 +72,7 @@ help_for_addq() {
     cat <<EOF
   SYNOPSIS:
 
-    alces compute addq <queue> [<size> [<min> [<max>]]]
+    $cw_BINNAME compute addq <queue> [<size> [<min> [<max>]]]
 
   DESCRIPTION:
 
@@ -88,7 +88,7 @@ help_for_delq() {
     cat <<EOF
   SYNOPSIS:
 
-    alces compute delq <queue>
+    $cw_BINNAME compute delq <queue>
 
   DESCRIPTION:
 
@@ -101,7 +101,7 @@ help_for_modq() {
     cat <<EOF
   SYNOPSIS:
 
-    alces compute modq <queue> <size> <min> <max>
+    $cw_BINNAME compute modq <queue> <size> <min> <max>
 
   DESCRIPTION:
 
@@ -115,7 +115,7 @@ help_for_expand() {
     cat <<EOF
   SYNOPSIS:
 
-    alces compute expand <queue> <size>
+    $cw_BINNAME compute expand <queue> <size>
 
   DESCRIPTION:
 
@@ -131,7 +131,7 @@ help_for_reduce() {
     cat <<EOF
   SYNOPSIS:
 
-    alces compute reduce <queue> <size>
+    $cw_BINNAME compute reduce <queue> <size>
 
   DESCRIPTION:
 
@@ -147,7 +147,7 @@ help_for_shoot() {
     cat <<EOF
   SYNOPSIS:
 
-    alces compute shoot <queue> <node>
+    $cw_BINNAME compute shoot <queue> <node>
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-compute/package/metadata.json
+++ b/clusterware/clusterware-compute/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "clusterware-compute",
-    "version": "2.0.0-dev",
+    "version": "2.0.1",
     "summary": "Clusterware extensions for management of compute queues",
     "dependencies": [
     ]

--- a/clusterware/clusterware-config/lib/functions/clocksource.functions.sh
+++ b/clusterware/clusterware-config/lib/functions/clocksource.functions.sh
@@ -132,10 +132,10 @@ clocksource_list() {
     files_load_config --optional cluster-clocksource
     clocksources="default $(_clocksource_get_available)"
     cur=$(cat $cw_CLOCKSOURCE_current_file)
-    
+
     if [[ ! -z "$cw_CLUSTER_clocksource" ]] && [[ "$cw_CLUSTER_clocksource" != "$cur" ]]; then
         action_warn "Conflict between system clocksource and config detected"
-        action_warn "Run to fix conflict: alces configure clocksource <source>"
+        action_warn "Run to fix conflict: $cw_BINNAME configure clocksource <source>"
     fi
     if [[ -z "$cw_CLUSTER_default_clocksource" ]]; then
         default_set="default"

--- a/clusterware/clusterware-config/libexec/configure/actions/help
+++ b/clusterware/clusterware-config/libexec/configure/actions/help
@@ -74,7 +74,7 @@ help_for_node() {
     cat <<EOF
   SYNOPSIS:
 
-    alces configure node
+    $cw_BINNAME configure node
 
   DESCRIPTION:
 
@@ -87,7 +87,7 @@ help_for_autoscaling() {
     cat <<EOF
   SYNOPSIS:
 
-    alces configure autoscaling [enable|disable|status]
+    $cw_BINNAME configure autoscaling [enable|disable|status]
 
   DESCRIPTION:
 
@@ -101,7 +101,7 @@ help_for_hyperthreading() {
     cat <<EOF
   SYNOPSIS:
 
-    alces configure hyperthreading [enable|disable|status]
+    $cw_BINNAME configure hyperthreading [enable|disable|status]
 
   DESCRIPTION:
 
@@ -115,9 +115,9 @@ help_for_scheduler() {
     cat <<EOF
   SYNOPSIS:
 
-    alces configure scheduler [status]
-    alces configure scheduler allocation <strategy>
-    alces configure scheduler submission <strategy>
+    $cw_BINNAME configure scheduler [status]
+    $cw_BINNAME configure scheduler allocation <strategy>
+    $cw_BINNAME configure scheduler submission <strategy>
 
   DESCRIPTION:
 
@@ -139,7 +139,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces configure help [<command>]
+    $cw_BINNAME configure help [<command>]
 
   DESCRIPTION:
 
@@ -153,7 +153,7 @@ help_for_thp() {
   cat <<EOF
   SYNOPSIS:
 
-    alces configure thp [enable|disable|status]
+    $cw_BINNAME configure thp [enable|disable|status]
 
   DESCRIPTION:
 
@@ -170,7 +170,7 @@ help_for_clocksource() {
   cat <<EOF
   SYNOPSIS:
 
-    alces configure clocksource [default|$sources]
+    $cw_BINNAME configure clocksource [default|$sources]
 
   DESCRIPTION:
 
@@ -188,7 +188,7 @@ help_for_dropcache() {
   cat <<EOF
   SYNOPSIS:
 
-    alces configure dropcache <pagecache|slabobjs|both>
+    $cw_BINNAME configure dropcache <pagecache|slabobjs|both>
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-config/libexec/configure/actions/node
+++ b/clusterware/clusterware-config/libexec/configure/actions/node
@@ -162,7 +162,7 @@ prompt will be updated to include the name of your cluster.
 
 Once configured, you can access the information required to
 configure further nodes as part of your cluster by running the
-"$(echo -e "\e[1;37m")alces about identity$(echo -e "\e[0m")" command.
+"$(echo -e "\e[1;37m")$cw_BINNAME about identity$(echo -e "\e[0m")" command.
 
 EOF
 }

--- a/clusterware/clusterware-config/package/metadata.json
+++ b/clusterware/clusterware-config/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "clusterware-config",
-    "version": "2.0.0-dev",
+    "version": "2.0.1",
     "summary": "Utilities for configuring Clusterware nodes",
     "dependencies": [
     ]

--- a/clusterware/clusterware-customize/lib/functions/customize-slave.functions.sh
+++ b/clusterware/clusterware-customize/lib/functions/customize-slave.functions.sh
@@ -144,9 +144,9 @@ customize_slave_help() {
   cat <<EOF
 SYNOPSIS:
 
-  alces customize slave add <repo>/<profile>
-  alces customize slave remove <repo>/<profile>
-  alces customize slave list
+  $cw_BINNAME customize slave add <repo>/<profile>
+  $cw_BINNAME customize slave remove <repo>/<profile>
+  $cw_BINNAME customize slave list
 
 DESCRIPTION:
   Manage customization profiles to be executed by slave nodes on boot.

--- a/clusterware/clusterware-customize/libexec/customize/actions/help
+++ b/clusterware/clusterware-customize/libexec/customize/actions/help
@@ -45,7 +45,7 @@ help_for_apply() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize apply [OPTIONS] <profile>
+    $cw_BINNAME customize apply [OPTIONS] <profile>
 
   DESCRIPTION:
 
@@ -53,7 +53,7 @@ help_for_apply() {
     node or, optionally, a list of other nodes in the cluster.
 
     A list of available customization profiles can be shown by
-    running "alces customize avail".
+    running "$cw_BINNAME customize avail".
 
     Once downloaded, the customization will have its configure event
     triggered, along with a member-join event for each current member
@@ -74,7 +74,7 @@ help_for_avail() {
   cat <<EOF
 SYNOPSIS:
 
-  alces customize avail
+  $cw_BINNAME customize avail
 
 DESCRIPTION:
 
@@ -87,7 +87,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize help [<command>]
+    $cw_BINNAME customize help [<command>]
 
   DESCRIPTION:
 
@@ -105,7 +105,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces handler list [OPTIONS]
+    $cw_BINNAME handler list [OPTIONS]
 
   DESCRIPTION:
 
@@ -123,7 +123,7 @@ help_for_pull() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize pull
+    $cw_BINNAME customize pull
 
   DESCRIPTION:
 
@@ -136,7 +136,7 @@ help_for_trigger() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize trigger [OPTIONS] <event> [<profile>]
+    $cw_BINNAME customize trigger [OPTIONS] <event> [<profile>]
 
   DESCRIPTION:
 
@@ -156,7 +156,7 @@ help_for_push() {
   cat <<EOF
   SYNOPSIS:
 
-    alces customize push <source> [repository] [hook]
+    $cw_BINNAME customize push <source> [repository] [hook]
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-customize/libexec/customize/actions/job-queue-actions/help
+++ b/clusterware/clusterware-customize/libexec/customize/actions/job-queue-actions/help
@@ -46,7 +46,7 @@ help_for_get-output() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize job-queue get-output <queue> <job_id> <output_file>
+    $cw_BINNAME customize job-queue get-output <queue> <job_id> <output_file>
 
   DESCRIPTION:
 
@@ -60,7 +60,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize job-queue help [<command>]
+    $cw_BINNAME customize job-queue help [<command>]
 
   DESCRIPTION:
 
@@ -74,7 +74,7 @@ help_for_list-jobs() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize job-queue list-jobs <queue>
+    $cw_BINNAME customize job-queue list-jobs <queue>
 
   DESCRIPTION:
 
@@ -87,7 +87,7 @@ help_for_list-output() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize job-queue list-output <queue>
+    $cw_BINNAME customize job-queue list-output <queue>
 
   DESCRIPTION:
 
@@ -100,7 +100,7 @@ help_for_list-queues() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize job-queue list-queues
+    $cw_BINNAME customize job-queue list-queues
 
   DESCRIPTION:
 
@@ -113,7 +113,7 @@ help_for_put() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize job-queue put <queue> <FILE>
+    $cw_BINNAME customize job-queue put <queue> <FILE>
 
   DESCRIPTION:
 
@@ -126,7 +126,7 @@ help_for_rm() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize job-queue rm <queue> <job_id>
+    $cw_BINNAME customize job-queue rm <queue> <job_id>
 
   DESCRIPTION:
 
@@ -139,7 +139,7 @@ help_for_status() {
     cat <<EOF
   SYNOPSIS:
 
-    alces customize job-queue status <queue> <job_id>
+    $cw_BINNAME customize job-queue status <queue> <job_id>
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-docs/etc/motd.d/00-tips-00-clusterware-docs.txt
+++ b/clusterware/clusterware-docs/etc/motd.d/00-tips-00-clusterware-docs.txt
@@ -6,6 +6,6 @@
 ################################################################################
 TIPS:
 
-'alces help'              - get help on available commands
-'alces howto'             - guides on how to use your research environment
-'alces template'          - tailored job script templates
+'flight help'             - get help on available commands
+'flight howto'            - guides on how to use your research environment
+'flight template'         - tailored job script templates

--- a/clusterware/clusterware-docs/libexec/howto/actions/help
+++ b/clusterware/clusterware-docs/libexec/howto/actions/help
@@ -45,7 +45,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces howto list
+    $cw_BINNAME howto list
 
   DESCRIPTION:
 
@@ -58,8 +58,8 @@ help_for_show() {
     cat <<EOF
   SYNOPSIS:
 
-    alces howto show <index|name>
-    alces howto <index|name>
+    $cw_BINNAME howto show <index|name>
+    $cw_BINNAME howto <index|name>
 
   DESCRIPTION:
 
@@ -76,7 +76,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces howto help [<command>]
+    $cw_BINNAME howto help [<command>]
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-docs/libexec/template/actions/help
+++ b/clusterware/clusterware-docs/libexec/template/actions/help
@@ -45,7 +45,7 @@ help_for_copy() {
     cat <<EOF
   SYNOPSIS:
 
-    alces template copy <index|name> <target>
+    $cw_BINNAME template copy <index|name> <target>
 
   DESCRIPTION:
 
@@ -60,7 +60,7 @@ help_for_info() {
     cat <<EOF
   SYNOPSIS:
 
-    alces template info <index|name>
+    $cw_BINNAME template info <index|name>
 
   DESCRIPTION:
 
@@ -77,7 +77,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces template list
+    $cw_BINNAME template list
 
   DESCRIPTION:
 
@@ -90,7 +90,7 @@ help_for_show() {
     cat <<EOF
   SYNOPSIS:
 
-    alces template show <index|name>
+    $cw_BINNAME template show <index|name>
 
   DESCRIPTION:
 
@@ -103,7 +103,7 @@ help_for_prepare() {
     cat <<EOF
   SYNOPSIS:
 
-    alces template prepare <index|name>
+    $cw_BINNAME template prepare <index|name>
 
   DESCRIPTION:
 
@@ -117,7 +117,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces template help [<command>]
+    $cw_BINNAME template help [<command>]
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-docs/libexec/template/actions/prepare
+++ b/clusterware/clusterware-docs/libexec/template/actions/prepare
@@ -50,7 +50,7 @@ main() {
                             set -o pipefail
                             if ! ${type}_storage_get gridware-data "$f" "${datadir}" | stdbuf -oL sed -e "s/^/$cw_BINNAME: /g"; then
                                 rm -rf "${datadir}"
-                                action_die "unable to download '$f' from 'gridware-data' storage backend - please consult the template documentation ('alces template info $1') for details regarding data acquisition" 1
+                                action_die "unable to download '$f' from 'gridware-data' storage backend - please consult the template documentation ('$cw_BINNAME template info $1') for details regarding data acquisition" 1
                             else
                                 if [[ "$f" == *.al.gr.tar.gz ]]; then
                                     action_warn "extracting Gridware data archive"
@@ -66,7 +66,7 @@ main() {
                         action_die "storage backend for the 'gridware-data' storage configuration cannot be loaded (${type})" 1
                     fi
                 else
-                    action_die "unable to find 'gridware-data' storage configuration - please consult the template documentation ('alces template info $1') for details regarding data acquisition" 1
+                    action_die "unable to find 'gridware-data' storage configuration - please consult the template documentation ('$cw_BINNAME template info $1') for details regarding data acquisition" 1
                 fi
                 :
             else

--- a/clusterware/clusterware-docs/package/metadata.json
+++ b/clusterware/clusterware-docs/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "clusterware-docs",
-    "version": "2.1.0-dev",
+    "version": "2.1.1",
     "summary": "Clusterware documentation",
     "dependencies": [
     ]

--- a/clusterware/clusterware-gridware/docs/guides/20-work-with-applications.md
+++ b/clusterware/clusterware-gridware/docs/guides/20-work-with-applications.md
@@ -28,18 +28,18 @@ see the "How to run graphical jobs" guide
 
 ## ALCES GRIDWARE UTILITY
 
-The `alces gridware` utility provides a simple interface for installing
+The `flight gridware` utility provides a simple interface for installing
 applications, compilers and accelerated libraries to your environment. 
 Only privileged users of an environment are granted access to the Gridware
 utility.
 
 To view all of the available Gridware packages: 
 
-    alces gridware list
+    flight gridware list
 
 To search for specific Gridware packages by name: 
 
-    alces gridware search --name python
+    flight gridware search --name python
     base/apps/ipython/2.3.0   base/apps/python/2.7.3    base/apps/python/2.7.5
     base/apps/python/2.7.8    base/apps/python3/3.2.3   base/apps/python3/3.3.3
     base/apps/python3/3.4.0   base/apps/python3/3.4.3   base/libs/biopython/1.61
@@ -48,7 +48,7 @@ To search for specific Gridware packages by name:
 To install an application to your environment, making it 
 immediately available for use via the `module` command:
 
-    alces gridware install apps/memtester/4.3.0
+    flight gridware install apps/memtester/4.3.0
 
 ## THE MODULE COMMAND
 

--- a/clusterware/clusterware-gridware/etc/motd.d/00-tips-05-gridware.txt
+++ b/clusterware/clusterware-gridware/etc/motd.d/00-tips-05-gridware.txt
@@ -4,7 +4,7 @@
 ## Copyright (c) 2016 Stephen F. Norledge and Alces Software Ltd
 ##
 ################################################################################
-'alces gridware'          - manage software for your environment
+'flight gridware'         - manage software for your environment
 
 'module avail'            - show available application environments
 'module add <modulename>' - add a module to your current environment

--- a/clusterware/clusterware-gridware/libexec/actions/gridware
+++ b/clusterware/clusterware-gridware/libexec/actions/gridware
@@ -38,7 +38,7 @@ if [ "" ]; then 0; else eval 'cw_RUBY_EXEC "$@" || exit 1'; fi; end
 if Process.euid != 0
   v = `bash -c 'source #{ENV['cw_ROOT']}/etc/gridware.rc 2> /dev/null && echo ${cw_GRIDWARE_allow_users}'`.chomp
   if v == 'false'
-    STDERR.puts "alces gridware: user-level access is unavailable; contact your support representative for package installations"
+    STDERR.puts "flight gridware: user-level access is unavailable; contact your support representative for package installations"
     exit(1)
   end
   ENV['cw_GRIDWARE_userspace'] = ENV['USER']
@@ -64,7 +64,7 @@ else
 
   if ! File.exist?("#{ENV['cw_GRIDWARE_root']}/etc/gridware.yml") &&
      ! File.exist?("#{ENV['cw_ROOT']}/etc/gridware.yml")
-    STDERR.puts "alces gridware: uninitialized; try 'alces gridware init' first"
+    STDERR.puts "flight gridware: uninitialized; try 'flight gridware init' first"
     exit 1
   end
 end

--- a/clusterware/clusterware-gridware/libexec/gridware/actions/docker_build
+++ b/clusterware/clusterware-gridware/libexec/gridware/actions/docker_build
@@ -186,7 +186,7 @@ EOF
   fi
 }
 
-cw_BINNAME="alces gridware"
+cw_BINNAME="$cw_BINNAME gridware"
 
 setup
 require action

--- a/clusterware/clusterware-gridware/libexec/gridware/actions/docker_help
+++ b/clusterware/clusterware-gridware/libexec/gridware/actions/docker_help
@@ -45,7 +45,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker help [<command>]
+    $cw_BINNAME gridware docker help [<command>]
 
   DESCRIPTION:
 
@@ -59,7 +59,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker list
+    $cw_BINNAME gridware docker list
 
   DESCRIPTION:
 
@@ -72,7 +72,7 @@ help_for_build() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker build [OPTIONS] <package> [--variant <variant>] [<package> [--variant <variant>] ...]
+    $cw_BINNAME gridware docker build [OPTIONS] <package> [--variant <variant>] [<package> [--variant <variant>] ...]
 
   DESCRIPTION:
 
@@ -104,7 +104,7 @@ help_for_push() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker push [OPTIONS] <package>
+    $cw_BINNAME gridware docker push [OPTIONS] <package>
 
   DESCRIPTION:
 
@@ -123,7 +123,7 @@ help_for_pull() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker pull <package>
+    $cw_BINNAME gridware docker pull <package>
 
   DESCRIPTION:
 
@@ -137,7 +137,7 @@ help_for_run() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker run [OPTIONS] <package> [<runmode>] [PARAMS...]
+    $cw_BINNAME gridware docker run [OPTIONS] <package> [<runmode>] [PARAMS...]
 
   DESCRIPTION:
 
@@ -196,7 +196,7 @@ help_for_share() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker share <package>
+    $cw_BINNAME gridware docker share <package>
 
   DESCRIPTION:
 
@@ -204,7 +204,7 @@ help_for_share() {
     cluster.
 
     The image must already be available on the node from which this command is
-    run (e.g. have been used with 'alces gridware docker pull' or 'alces
+    run (e.g. have been used with '$cw_BINNAME gridware docker pull' or '$cw_BINNAME
     gridware docker run'). Other nodes in the cluster will automatically import
     the image, making it available to run on each node.
 
@@ -215,7 +215,7 @@ help_for_start-registry() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker start-registry
+    $cw_BINNAME gridware docker start-registry
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-gridware/libexec/gridware/actions/docker_list
+++ b/clusterware/clusterware-gridware/libexec/gridware/actions/docker_list
@@ -56,7 +56,7 @@ main() {
     done
 }
 
-cw_BINNAME="alces gridware"
+cw_BINNAME="$cw_BINNAME gridware"
 
 setup
 require action

--- a/clusterware/clusterware-gridware/libexec/gridware/actions/docker_push
+++ b/clusterware/clusterware-gridware/libexec/gridware/actions/docker_push
@@ -69,7 +69,7 @@ main() {
     fi
 }
 
-cw_BINNAME="alces gridware"
+cw_BINNAME="$cw_BINNAME gridware"
 
 setup
 require action

--- a/clusterware/clusterware-gridware/libexec/gridware/actions/docker_run
+++ b/clusterware/clusterware-gridware/libexec/gridware/actions/docker_run
@@ -142,7 +142,7 @@ main() {
     fi
 }
 
-cw_BINNAME="alces gridware"
+cw_BINNAME="$cw_BINNAME gridware"
 
 setup
 require action

--- a/clusterware/clusterware-gridware/libexec/gridware/actions/docker_share
+++ b/clusterware/clusterware-gridware/libexec/gridware/actions/docker_share
@@ -55,7 +55,7 @@ main() {
   fi
 }
 
-cw_BINNAME="alces gridware"
+cw_BINNAME="$cw_BINNAME gridware"
 
 setup
 require action

--- a/clusterware/clusterware-gridware/libexec/gridware/actions/docker_start_registry
+++ b/clusterware/clusterware-gridware/libexec/gridware/actions/docker_start_registry
@@ -57,7 +57,7 @@ main() {
 
 }
 
-cw_BINNAME="alces gridware"
+cw_BINNAME="$cw_BINNAME gridware"
 
 setup
 require action

--- a/clusterware/clusterware-gridware/package/metadata.json
+++ b/clusterware/clusterware-gridware/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "clusterware-gridware",
-    "version": "2.1.1-dev",
+    "version": "2.1.2",
     "summary": "Alces Gridware integration for Clusterware",
     "username": "alces",
     "dependencies": [

--- a/clusterware/clusterware-sessions/docs/guides/25-secure-vnc-sessions.md
+++ b/clusterware/clusterware-sessions/docs/guides/25-secure-vnc-sessions.md
@@ -27,7 +27,7 @@ how to provision an Alces Flight Access appliance.
 ## CLUSTERWARE VPN
 
 Clusterware may be configured with an OpenVPN service.  Refer to the
-`alces about vpn` command to locate the configuration files for your
+`flight about vpn` command to locate the configuration files for your
 platform.  You can find OpenVPN downloads and documentation for your
 client system at <https://openvpn.net/>.
 

--- a/clusterware/clusterware-sessions/etc/motd.d/00-tips-02-clusterware.txt
+++ b/clusterware/clusterware-sessions/etc/motd.d/00-tips-02-clusterware.txt
@@ -1,1 +1,1 @@
-'alces session'           - start and manage interactive sessions
+'flight session'          - start and manage interactive sessions

--- a/clusterware/clusterware-sessions/libexec/session/actions/help
+++ b/clusterware/clusterware-sessions/libexec/session/actions/help
@@ -45,7 +45,7 @@ help_for_avail() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session avail
+    $cw_BINNAME session avail
 
   DESCRIPTION:
 
@@ -59,7 +59,7 @@ help_for_clean() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session clean [<session identity>]
+    $cw_BINNAME session clean [<session identity>]
 
   DESCRIPTION:
 
@@ -82,7 +82,7 @@ help_for_disable() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session disable <type>
+    $cw_BINNAME session disable <type>
 
   DESCRIPTION:
 
@@ -96,7 +96,7 @@ help_for_enable() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session enable [<repository>/]<type> [PARAMS...]
+    $cw_BINNAME session enable [<repository>/]<type> [PARAMS...]
 
   DESCRIPTION:
 
@@ -123,7 +123,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session help [<command>]
+    $cw_BINNAME session help [<command>]
 
   DESCRIPTION:
 
@@ -137,7 +137,7 @@ help_for_info() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session info [OPTIONS] <session identity>
+    $cw_BINNAME session info [OPTIONS] <session identity>
 
   DESCRIPTION:
 
@@ -159,7 +159,7 @@ help_for_kill() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session kill <session identity>
+    $cw_BINNAME session kill <session identity>
 
   DESCRIPTION:
 
@@ -175,7 +175,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session list [OPTIONS]
+    $cw_BINNAME session list [OPTIONS]
 
   DESCRIPTION:
 
@@ -201,7 +201,7 @@ help_for_start() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session start [OPTIONS] <type> [PARAMS...]
+    $cw_BINNAME session start [OPTIONS] <type> [PARAMS...]
 
   DESCRIPTION:
 
@@ -237,7 +237,7 @@ help_for_update() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session update [<repository> <url>]
+    $cw_BINNAME session update [<repository> <url>]
 
   DESCRIPTION:
 
@@ -256,7 +256,7 @@ help_for_wait() {
     cat <<EOF
   SYNOPSIS:
 
-    alces session wait <session identity>
+    $cw_BINNAME session wait <session identity>
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-sessions/libexec/session/actions/start
+++ b/clusterware/clusterware-sessions/libexec/session/actions/start
@@ -273,8 +273,8 @@ You should consider securing your session by:
  * connecting via the Clusterware VPN
  * using an SSH port forward (either manually, or via a tool like "ssvnc")
 
-Please run the "alces howto secure-vnc-sessions" command for further details or
-refer to the Alces Flight Compute documentation <http://docs.alces-flight.com>.
+Please run the "flight howto secure-vnc-sessions" command for further details
+or refer to the Alces Flight Compute documentation <http://docs.alces-flight.com>.
 
 EOF
            while [ "$confirm" != "y" -a "${confirm}" != "n" ]; do

--- a/clusterware/clusterware-sessions/package/metadata.json
+++ b/clusterware/clusterware-sessions/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "clusterware-sessions",
-    "version": "2.1.2-dev",
+    "version": "2.1.3",
     "summary": "Clusterware session support",
     "dependencies": [
       "alces/tigervnc",

--- a/clusterware/clusterware-storage/etc/motd.d/00-tips-01-clusterware.txt
+++ b/clusterware/clusterware-storage/etc/motd.d/00-tips-01-clusterware.txt
@@ -1,1 +1,1 @@
-'alces storage'           - configure and address storage facilities
+'flight storage'           - configure and address storage facilities

--- a/clusterware/clusterware-storage/etc/motd.d/00-tips-01-clusterware.txt
+++ b/clusterware/clusterware-storage/etc/motd.d/00-tips-01-clusterware.txt
@@ -1,1 +1,1 @@
-'flight storage'           - configure and address storage facilities
+'flight storage'          - configure and address storage facilities

--- a/clusterware/clusterware-storage/libexec/storage/actions/help
+++ b/clusterware/clusterware-storage/libexec/storage/actions/help
@@ -45,7 +45,7 @@ help_for_show() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage show
+    $cw_BINNAME storage show
 
   DESCRIPTION:
 
@@ -60,7 +60,7 @@ help_for_avail() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage avail
+    $cw_BINNAME storage avail
 
   DESCRIPTION:
 
@@ -73,7 +73,7 @@ help_for_configure() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage configure [OPTIONS] <name> <type> [PARAMS...]
+    $cw_BINNAME storage configure [OPTIONS] <name> <type> [PARAMS...]
 
   DESCRIPTION:
 
@@ -99,7 +99,7 @@ help_for_enable() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage enable <type>
+    $cw_BINNAME storage enable <type>
 
   DESCRIPTION:
 
@@ -112,7 +112,7 @@ help_for_forget() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage forget [OPTIONS] <name>
+    $cw_BINNAME storage forget [OPTIONS] <name>
 
   DESCRIPTION:
 
@@ -131,7 +131,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage help [<command>]
+    $cw_BINNAME storage help [<command>]
 
   DESCRIPTION:
 
@@ -145,7 +145,7 @@ help_for_use() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage use [OPTIONS] <name>
+    $cw_BINNAME storage use [OPTIONS] <name>
 
   DESCRIPTION:
 
@@ -168,7 +168,7 @@ help_for_put() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage put [OPTIONS] <source> [<target>]
+    $cw_BINNAME storage put [OPTIONS] <source> [<target>]
 
   DESCRIPTION:
 
@@ -183,7 +183,7 @@ help_for_put() {
     -n <name>
      Use storage configuration with <name>.  If not specified, the
      current default (if present) will be used.  Change the default
-     with "alces storage use".
+     with "$cw_BINNAME storage use".
 
     -r, -R
      Recursively put a local <source> directory to a remote <target>
@@ -195,7 +195,7 @@ help_for_get() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage get [OPTIONS] <source> [<target>]
+    $cw_BINNAME storage get [OPTIONS] <source> [<target>]
 
   DESCRIPTION:
 
@@ -209,7 +209,7 @@ help_for_get() {
     -n <name>
      Use storage configuration with <name>.  If not specified, the
      current default (if present) will be used.  Change the default
-     with "alces storage use".
+     with "$cw_BINNAME storage use".
 
     -r, -R
      Recursively get a remote <source> directory to a local <target>
@@ -225,7 +225,7 @@ help_for_rm() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage rm [OPTIONS] <path>
+    $cw_BINNAME storage rm [OPTIONS] <path>
 
   DESCRIPTION:
 
@@ -236,7 +236,7 @@ help_for_rm() {
     -n <name>
      Use storage configuration with <name>.  If not specified, the
      current default (if present) will be used.  Change the default
-     with "alces storage use".
+     with "$cw_BINNAME storage use".
 
     -r, -R
      Recursively remove a remote directory at <path>.  You will be
@@ -252,7 +252,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage list [OPTIONS] [<path>]
+    $cw_BINNAME storage list [OPTIONS] [<path>]
 
   DESCRIPTION:
 
@@ -263,7 +263,7 @@ help_for_list() {
     -n <name>
      Use storage configuration with <name>.  If not specified, the
      current default (if present) will be used.  Change the default
-     with "alces storage use".
+     with "$cw_BINNAME storage use".
 
 EOF
 }
@@ -272,8 +272,8 @@ help_for_mkbucket() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage mkbucket [OPTIONS] <name>
-    alces storage mkdir [OPTIONS] <name>
+    $cw_BINNAME storage mkbucket [OPTIONS] <name>
+    $cw_BINNAME storage mkdir [OPTIONS] <name>
 
   DESCRIPTION:
 
@@ -285,7 +285,7 @@ help_for_mkbucket() {
     -n <name>
      Use storage configuration with <name>.  If not specified, the
      current default (if present) will be used.  Change the default
-     with "alces storage use".
+     with "$cw_BINNAME storage use".
 
 EOF
 }
@@ -294,8 +294,8 @@ help_for_rmbucket() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage rmbucket [OPTIONS] <name>
-    alces storage rmdir [OPTIONS] <name>
+    $cw_BINNAME storage rmbucket [OPTIONS] <name>
+    $cw_BINNAME storage rmdir [OPTIONS] <name>
 
   DESCRIPTION:
 
@@ -307,7 +307,7 @@ help_for_rmbucket() {
     -n <name>
      Use storage configuration with <name>.  If not specified, the
      current default (if present) will be used.  Change the default
-     with "alces storage use".
+     with "$cw_BINNAME storage use".
 
 EOF
 }
@@ -316,7 +316,7 @@ help_for_addbucket() {
     cat <<EOF
   SYNOPSIS:
 
-    alces storage addbucket [OPTIONS] <name>
+    $cw_BINNAME storage addbucket [OPTIONS] <name>
 
   DESCRIPTION:
 
@@ -325,7 +325,7 @@ help_for_addbucket() {
     This acts as a convenient reminder or hint that further buckets
     are available when using a storage configuration, even if it is
     not owned by the configured account (e.g. public buckets).
-    External buckets will be shown when using "alces storage list"
+    External buckets will be shown when using "$cw_BINNAME storage list"
     with no parameters.
 
     Note that not all storage backends support this operation.
@@ -335,7 +335,7 @@ help_for_addbucket() {
     -n <name>
      Use storage configuration with <name>.  If not specified, the
      current default (if present) will be used.  Change the default
-     with "alces storage use".
+     with "$cw_BINNAME storage use".
 
 EOF
 }

--- a/clusterware/clusterware-storage/package/metadata.json
+++ b/clusterware/clusterware-storage/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "clusterware-storage",
-    "version": "2.1.1-dev",
+    "version": "2.1.2",
     "summary": "Clusterware storage utilities",
     "dependencies": [
       "alces/pdsh"

--- a/clusterware/clusterware-sync/libexec/sync/actions/help
+++ b/clusterware/clusterware-sync/libexec/sync/actions/help
@@ -45,7 +45,7 @@ help_for_add() {
     cat <<EOF
   SYNOPSIS:
 
-    alces sync add <name> <directory>
+    $cw_BINNAME sync add <name> <directory>
 
   DESCRIPTION:
 
@@ -59,7 +59,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces sync help [<command>]
+    $cw_BINNAME sync help [<command>]
 
   DESCRIPTION:
 
@@ -73,7 +73,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces sync list
+    $cw_BINNAME sync list
 
   DESCRIPTION:
 
@@ -86,7 +86,7 @@ help_for_pull() {
     cat <<EOF
   SYNOPSIS:
 
-    alces sync pull [OPTIONS] [<name>]
+    $cw_BINNAME sync pull [OPTIONS] [<name>]
 
   DESCRIPTION:
 
@@ -109,7 +109,7 @@ help_for_purge() {
     cat <<EOF
   SYNOPSIS:
 
-    alces sync purge <name>
+    $cw_BINNAME sync purge <name>
 
   DESCRIPTION:
 
@@ -124,7 +124,7 @@ help_for_push() {
     cat <<EOF
   SYNOPSIS:
 
-    alces sync push [<name>]
+    $cw_BINNAME sync push [<name>]
 
   DESCRIPTION:
 
@@ -139,7 +139,7 @@ help_for_remove() {
     cat <<EOF
   SYNOPSIS:
 
-    alces sync remove <name>
+    $cw_BINNAME sync remove <name>
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-sync/package/metadata.json
+++ b/clusterware/clusterware-sync/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "clusterware-sync",
-    "version": "2.0.0-dev",
+    "version": "2.0.1",
     "summary": "Clusterware profile sync utility",
     "dependencies": [
       "alces/s3cmd"

--- a/clusterware/clusterware-tips/libexec/tips/actions/help
+++ b/clusterware/clusterware-tips/libexec/tips/actions/help
@@ -45,7 +45,7 @@ help_for_disable() {
     cat <<EOF
   SYNOPSIS:
 
-    alces tips disable
+    $cw_BINNAME tips disable
 
   DESCRIPTION:
 
@@ -58,7 +58,7 @@ help_for_enable() {
     cat <<EOF
   SYNOPSIS:
 
-    alces tips enable
+    $cw_BINNAME tips enable
 
   DESCRIPTION:
 
@@ -71,7 +71,7 @@ help_for_list() {
     cat <<EOF
   SYNOPSIS:
 
-    alces tips [list]
+    $cw_BINNAME tips [list]
 
   DESCRIPTION:
 
@@ -84,7 +84,7 @@ help_for_show() {
     cat <<EOF
   SYNOPSIS:
 
-    alces tips [show] [--short] [--random|<topic>]
+    $cw_BINNAME tips [show] [--short] [--random|<topic>]
 
   DESCRIPTION:
 
@@ -99,7 +99,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces tips help [<command>]
+    $cw_BINNAME tips help [<command>]
 
   DESCRIPTION:
 

--- a/clusterware/clusterware-tips/package/metadata.json
+++ b/clusterware/clusterware-tips/package/metadata.json
@@ -2,7 +2,7 @@
   "type": "packages",
   "attributes": {
     "name": "clusterware-tips",
-    "version": "2.0.0-dev",
+    "version": "2.0.1",
     "summary": "Provides tips for using a Clusterware environment",
     "dependencies": [
       "alces/clusterware-docs"

--- a/clusterware/clusterware-tips/var/lib/docs/base/tips/disable-tips.tip
+++ b/clusterware/clusterware-tips/var/lib/docs/base/tips/disable-tips.tip
@@ -1,3 +1,3 @@
 #help #commands #tools
-%if you don't want to see tips, disable them with the `alces tips` command.
-If you don't want to see tips, disable them with the `alces tips` command.
+%if you don't want to see tips, disable them with the `flight tips` command.
+If you don't want to see tips, disable them with the `flight tips` command.

--- a/clusterware/clusterware-tips/var/lib/docs/base/tips/discover-tips.tip
+++ b/clusterware/clusterware-tips/var/lib/docs/base/tips/discover-tips.tip
@@ -1,3 +1,3 @@
 #help #commands #tools
-%discover more tips using the `alces tips` command.
-Discover more tips using the `alces tips` command.
+%discover more tips using the `flight tips` command.
+Discover more tips using the `flight tips` command.

--- a/clusterware/clusterware-tips/var/lib/docs/base/tips/get-help.tip
+++ b/clusterware/clusterware-tips/var/lib/docs/base/tips/get-help.tip
@@ -1,3 +1,3 @@
 #help #commands #tools
-%you can get help by running the `alces help` command.
-You can get help by running the `alces help` command.
+%you can get help by running the `flight help` command.
+You can get help by running the `flight help` command.

--- a/clusterware/clusterware-tips/var/lib/docs/base/tips/learn-about-your-cluster.tip
+++ b/clusterware/clusterware-tips/var/lib/docs/base/tips/learn-about-your-cluster.tip
@@ -1,3 +1,3 @@
 #help #commands #tools
-%learn about your cluster with the `alces about` command.
-Learn about your cluster with the `alces about` command.
+%learn about your cluster with the `flight about` command.
+Learn about your cluster with the `flight about` command.


### PR DESCRIPTION
This PR goes through and rebrands the packages from `alces` to `flight`. These changes should be purely cosmetic and concern the `motd` and help pages mainly.

The `motd` needs to be hard coded to `flight` as they are directly printed to the terminal. The `help` pages however rely on `cw_BINNAME` to be set correctly. Historically this was set to `alces` and as such will continue to appear that way `FlightDirect` versions `2.1.2` and earlier.

A rebuilt version of flight will however set this correctly and thus will update the help text.